### PR TITLE
First implementation for ZMQ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 #########################################################
 
 set(GR_MPI_TRANSPORT                TRUE CACHE BOOL "Compile with support for MPI tasks and communicators.")
+set(GR_ZMQ_TRANSPORT                TRUE CACHE BOOL "Compile with support for ZMQ communicators.")
 set(GR_ENABLE_CPP_COVERAGE          FALSE CACHE BOOL "Enable coverage for c++ code.")
 
 #########################################################
@@ -81,9 +82,13 @@ add_library(GR_project_libraries INTERFACE )
 target_include_directories( GR_project_libraries
     INTERFACE
         ${CMAKE_SOURCE_DIR}/include)
+
+# This is necessary to do here because MPI has to be found BEFORE
+# finding Conduit. Otherwise, Conduit seems to hide/overwrite the MPI cmake variables 
 if(${GR_MPI_TRANSPORT})
     find_package(MPI REQUIRED)
 endif()
+
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(MACOSX TRUE)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,6 +4,7 @@ catch2/2.13.9
 lyra/1.5.1
 range-v3/0.11.0
 nlohmann_json/3.11.2
+cppzmq/4.7.1
 
 [generators]
 cmake

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(simplempi)
 add_subdirectory(mpibroadcast)
 add_subdirectory(mpipartialbcastgather)
+add_subdirectory(zmqpubsub)
+add_subdirectory(zmqpushpull)

--- a/examples/zmqpubsub/CMakeLists.txt
+++ b/examples/zmqpubsub/CMakeLists.txt
@@ -1,0 +1,30 @@
+add_executable(sendpubsub send.cpp)
+
+target_link_libraries(sendpubsub
+                                GR_project_libraries
+                                GR_project_options
+                                GR_project_warnings
+                                GodrickLib
+                                GodrickMPILib
+                                GodrickZMQLib)
+
+add_executable(receivepubsub receive.cpp)
+
+target_link_libraries(receivepubsub
+                                GR_project_libraries
+                                GR_project_options
+                                GR_project_warnings
+                                GodrickLib
+                                GodrickMPILib
+                                GodrickZMQLib)
+
+install(TARGETS 
+            sendpubsub
+            receivepubsub
+        DESTINATION
+            ${GR_EXAMPLES_DIR}/zmqpubsub/bin)
+
+install(FILES 
+                    zmq_pubsub_workflow.py
+            DESTINATION 
+                    ${GR_EXAMPLES_DIR}/zmqpubsub)

--- a/examples/zmqpubsub/receive.cpp
+++ b/examples/zmqpubsub/receive.cpp
@@ -1,0 +1,66 @@
+#include <string>
+#include <thread>
+#include <chrono>
+
+#include <godrick/mpi/godrickMPI.h>
+
+#include <lyra/lyra.hpp>
+#include <spdlog/spdlog.h>
+
+#include <conduit/conduit.hpp>
+
+int main(int argc, char** argv)
+{
+    std::string taskName;
+    std::string configFile;
+
+    auto cli = lyra::cli()
+        | lyra::opt( taskName, "name" )
+            ["--name"]
+            ("Name of the task corresponding to the python workflow definition.")
+        | lyra::opt( configFile, "config" )
+            ["--config"]
+            ("Path to the config file.");
+
+    auto result = cli.parse( { argc, argv } );
+    if ( !result )
+    {
+        spdlog::critical("Unable to parse the command line: {}.", result.errorMessage());
+        exit(1);
+    }
+
+    spdlog::info("Starting the task {}.", taskName);
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    spdlog::info("Loading the workflow configuration {}.", configFile);
+    if(handler.initFromJSON(configFile, taskName))
+        spdlog::info("Configuration file loaded successfully.");
+    else
+    {
+        spdlog::error("Something went wrong during the workflow configuration.");
+        exit(-1);
+    }
+
+    std::vector<conduit::Node> receivedData;
+    uint32_t nbAttempts = 0;
+    while(!handler.get("in", receivedData))
+    {
+        nbAttempts++;
+        spdlog::warn("Failed to receive data attempt {}.", nbAttempts);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    if(receivedData.size() == 1)
+    {   
+        spdlog::info("Received {} conduit nodes.", receivedData.size());
+        receivedData[0].print_detailed();
+    }
+    else
+    {
+        spdlog::error("The receiver received something different than 1 conduit node during a broadcast.");
+    }
+
+    
+    handler.close();
+}

--- a/examples/zmqpubsub/send.cpp
+++ b/examples/zmqpubsub/send.cpp
@@ -1,0 +1,78 @@
+#include <string>
+#include <thread>
+#include <chrono>
+
+#include <godrick/mpi/godrickMPI.h>
+
+#include <lyra/lyra.hpp>
+#include <spdlog/spdlog.h>
+
+#include <conduit/conduit.hpp>
+
+int main(int argc, char** argv)
+{
+    std::string taskName;
+    std::string configFile;
+
+    auto cli = lyra::cli()
+        | lyra::opt( taskName, "name" )
+            ["--name"]
+            ("Name of the task corresponding to the python workflow definition.")
+        | lyra::opt( configFile, "config" )
+            ["--config"]
+            ("Path to the config file.");
+
+    auto result = cli.parse( { argc, argv } );
+    if ( !result )
+    {
+        spdlog::critical("Unable to parse the command line: {}.", result.errorMessage());
+        exit(1);
+    }
+
+    spdlog::info("Starting the task {}.", taskName);
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    spdlog::info("Loading the workflow configuration {}.", configFile);
+    if(handler.initFromJSON(configFile, taskName))
+        spdlog::info("Configuration file loaded successfully.");
+    else
+    {
+        spdlog::error("Something went wrong during the workflow configuration.");
+        exit(-1);
+    }
+
+    //auto taskRank = handler.getTaskRank();
+    auto taskComm = handler.getTaskCommunicator();
+    int taskCommSize;
+    MPI_Comm_size(taskComm, &taskCommSize);
+    if(taskCommSize != 1)
+    {
+        spdlog::info("Task {} has to be configured with a single rank ({} detected).", taskName, taskCommSize);
+        handler.close();
+
+        return EXIT_FAILURE;
+    }
+
+    // Sending the data
+    conduit::Node data;
+    uint32_t val = 10;
+    data["data"] = val;
+    data.print_detailed();
+
+    // Sending multiple messages in case the subscriber is a bit slow to connect.
+    uint32_t nbSends = 10;
+
+    for(uint32_t i = 0; i < nbSends; ++i)
+    {
+        if(handler.push("out", data))
+            spdlog::info("Data sent from the send task, iteration {}.", i);
+        else
+            spdlog::error("Something went wrong when sending the data.");
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        
+    }
+    
+    
+    handler.close();
+}

--- a/examples/zmqpubsub/send.cpp
+++ b/examples/zmqpubsub/send.cpp
@@ -61,6 +61,8 @@ int main(int argc, char** argv)
     data.print_detailed();
 
     // Sending multiple messages in case the subscriber is a bit slow to connect.
+    // If the sender send a message before the receiver is ready, the message 
+    // will be sent to nobody, and the receiver will wait forever.
     uint32_t nbSends = 10;
 
     for(uint32_t i = 0; i < nbSends; ++i)

--- a/examples/zmqpubsub/zmq_pubsub_workflow.py
+++ b/examples/zmqpubsub/zmq_pubsub_workflow.py
@@ -1,0 +1,41 @@
+from godrick.workflow import Workflow
+from godrick.task import MPITask, MPIPlacementPolicy
+from godrick.launcher import MainLauncher
+from godrick.computeResources import ComputeCollection
+from godrick.communicator import ZMQCommunicator, ZMQCommunicatorProtocol
+
+import os
+from pathlib import Path
+
+def main():
+    # Create resources
+    exampleFile = os.path.join(Path(__file__).resolve().parent, "../../data/tests/localhost.txt")
+    cluster = ComputeCollection(name="myCluster")
+    cluster.initFromHostFile(exampleFile, True)
+
+    workflow = Workflow("ZMQPubSubWorkflow")
+
+    partitions = cluster.splitNodesByCoreRange([1, 1])
+
+    task1 = MPITask(name="sendpubsub", cmdline="bin/sendpubsub --name sendpubsub --config config.ZMQPubSubWorkflow.json", placementPolicy=MPIPlacementPolicy.ONETASKPERCORE)
+    task1.addOutputPort("out")
+    task1.setResources(partitions[0])
+    task2 = MPITask(name="receivepubsub", cmdline="bin/receivepubsub --name receivepubsub --config config.ZMQPubSubWorkflow.json", placementPolicy=MPIPlacementPolicy.ONETASKPERCORE)
+    task2.addInputPort("in")
+    task2.setResources(partitions[1])
+
+    comm1 = ZMQCommunicator("myComm", protocol=ZMQCommunicatorProtocol.PUB_SUB)
+    comm1.connectInput(task2.getInputPort("in"))
+    comm1.connectOutput(task1.getOutputPort("out"))
+
+    workflow.declareTask(task1)
+    workflow.declareTask(task2)
+    workflow.declareCommunicator(comm1)
+
+    launcher = MainLauncher()
+    launcher.generateOutputFiles(workflow=workflow)
+
+
+# Boilerplate name guard
+if __name__ == "__main__":
+    main()

--- a/examples/zmqpushpull/CMakeLists.txt
+++ b/examples/zmqpushpull/CMakeLists.txt
@@ -1,0 +1,30 @@
+add_executable(sendpushpull send.cpp)
+
+target_link_libraries(sendpushpull
+                                GR_project_libraries
+                                GR_project_options
+                                GR_project_warnings
+                                GodrickLib
+                                GodrickMPILib
+                                GodrickZMQLib)
+
+add_executable(receivepushpull receive.cpp)
+
+target_link_libraries(receivepushpull
+                                GR_project_libraries
+                                GR_project_options
+                                GR_project_warnings
+                                GodrickLib
+                                GodrickMPILib
+                                GodrickZMQLib)
+
+install(TARGETS 
+            sendpushpull
+            receivepushpull
+        DESTINATION
+            ${GR_EXAMPLES_DIR}/zmqpushpull/bin)
+
+install(FILES 
+                    zmq_pushpull_workflow.py
+            DESTINATION 
+                    ${GR_EXAMPLES_DIR}/zmqpushpull)

--- a/examples/zmqpushpull/receive.cpp
+++ b/examples/zmqpushpull/receive.cpp
@@ -1,0 +1,61 @@
+#include <string>
+
+#include <godrick/mpi/godrickMPI.h>
+
+#include <lyra/lyra.hpp>
+#include <spdlog/spdlog.h>
+
+#include <conduit/conduit.hpp>
+
+int main(int argc, char** argv)
+{
+    std::string taskName;
+    std::string configFile;
+
+    auto cli = lyra::cli()
+        | lyra::opt( taskName, "name" )
+            ["--name"]
+            ("Name of the task corresponding to the python workflow definition.")
+        | lyra::opt( configFile, "config" )
+            ["--config"]
+            ("Path to the config file.");
+
+    auto result = cli.parse( { argc, argv } );
+    if ( !result )
+    {
+        spdlog::critical("Unable to parse the command line: {}.", result.errorMessage());
+        exit(1);
+    }
+
+    spdlog::info("Starting the task {}.", taskName);
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    spdlog::info("Loading the workflow configuration {}.", configFile);
+    if(handler.initFromJSON(configFile, taskName))
+        spdlog::info("Configuration file loaded successfully.");
+    else
+    {
+        spdlog::error("Something went wrong during the workflow configuration.");
+        exit(-1);
+    }
+
+    std::vector<conduit::Node> receivedData;
+    if(handler.get("in", receivedData))
+    {
+        if(receivedData.size() == 1)
+        {   
+            spdlog::info("Received {} conduit nodes.", receivedData.size());
+            receivedData[0].print_detailed();
+        }
+        else
+        {
+            spdlog::error("The receiver received something different than 1 conduit node during a broadcast.");
+        }
+    }
+    else 
+        spdlog::error("Something went wrong when receiving data.");
+
+    
+    handler.close();
+}

--- a/examples/zmqpushpull/send.cpp
+++ b/examples/zmqpushpull/send.cpp
@@ -1,0 +1,68 @@
+#include <string>
+
+#include <godrick/mpi/godrickMPI.h>
+
+#include <lyra/lyra.hpp>
+#include <spdlog/spdlog.h>
+
+#include <conduit/conduit.hpp>
+
+int main(int argc, char** argv)
+{
+    std::string taskName;
+    std::string configFile;
+
+    auto cli = lyra::cli()
+        | lyra::opt( taskName, "name" )
+            ["--name"]
+            ("Name of the task corresponding to the python workflow definition.")
+        | lyra::opt( configFile, "config" )
+            ["--config"]
+            ("Path to the config file.");
+
+    auto result = cli.parse( { argc, argv } );
+    if ( !result )
+    {
+        spdlog::critical("Unable to parse the command line: {}.", result.errorMessage());
+        exit(1);
+    }
+
+    spdlog::info("Starting the task {}.", taskName);
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    spdlog::info("Loading the workflow configuration {}.", configFile);
+    if(handler.initFromJSON(configFile, taskName))
+        spdlog::info("Configuration file loaded successfully.");
+    else
+    {
+        spdlog::error("Something went wrong during the workflow configuration.");
+        exit(-1);
+    }
+
+    //auto taskRank = handler.getTaskRank();
+    auto taskComm = handler.getTaskCommunicator();
+    int taskCommSize;
+    MPI_Comm_size(taskComm, &taskCommSize);
+    if(taskCommSize != 1)
+    {
+        spdlog::info("Task {} has to be configured with a single rank ({} detected).", taskName, taskCommSize);
+        handler.close();
+
+        return EXIT_FAILURE;
+    }
+
+    // Sending the data
+    conduit::Node data;
+    uint32_t val = 10;
+    data["data"] = val;
+    data.print_detailed();
+
+    if(handler.push("out", data))
+        spdlog::info("Data sent from the send task.");
+    else
+        spdlog::error("Something went wrong when sending the data.");
+    
+    
+    handler.close();
+}

--- a/examples/zmqpushpull/zmq_pushpull_workflow.py
+++ b/examples/zmqpushpull/zmq_pushpull_workflow.py
@@ -1,0 +1,41 @@
+from godrick.workflow import Workflow
+from godrick.task import MPITask, MPIPlacementPolicy
+from godrick.launcher import MainLauncher
+from godrick.computeResources import ComputeCollection
+from godrick.communicator import ZMQCommunicator, ZMQCommunicatorProtocol
+
+import os
+from pathlib import Path
+
+def main():
+    # Create resources
+    exampleFile = os.path.join(Path(__file__).resolve().parent, "../../data/tests/localhost.txt")
+    cluster = ComputeCollection(name="myCluster")
+    cluster.initFromHostFile(exampleFile, True)
+
+    workflow = Workflow("ZMQPushPullWorkflow")
+
+    partitions = cluster.splitNodesByCoreRange([1, 1])
+
+    task1 = MPITask(name="sendpushpull", cmdline="bin/sendpushpull --name sendpushpull --config config.ZMQPushPullWorkflow.json", placementPolicy=MPIPlacementPolicy.ONETASKPERCORE)
+    task1.addOutputPort("out")
+    task1.setResources(partitions[0])
+    task2 = MPITask(name="receivepushpull", cmdline="bin/receivepushpull --name receivepushpull --config config.ZMQPushPullWorkflow.json", placementPolicy=MPIPlacementPolicy.ONETASKPERCORE)
+    task2.addInputPort("in")
+    task2.setResources(partitions[1])
+
+    comm1 = ZMQCommunicator("myComm", protocol=ZMQCommunicatorProtocol.PUSH_PULL)
+    comm1.connectInput(task2.getInputPort("in"))
+    comm1.connectOutput(task1.getOutputPort("out"))
+
+    workflow.declareTask(task1)
+    workflow.declareTask(task2)
+    workflow.declareCommunicator(comm1)
+
+    launcher = MainLauncher()
+    launcher.generateOutputFiles(workflow=workflow)
+
+
+# Boilerplate name guard
+if __name__ == "__main__":
+    main()

--- a/include/godrick/communicator.h
+++ b/include/godrick/communicator.h
@@ -10,14 +10,14 @@
 using json = nlohmann::json;
 
 namespace godrick {
-    
+
 class Communicator
 {
 public:
     Communicator(){}
     virtual ~Communicator(){}
 
-    virtual bool initFromJSON(json& data);
+    virtual bool initFromJSON(json& data, const std::string& taskName);
 
     virtual bool send(conduit::Node& data) = 0;
     virtual bool receive(std::vector<conduit::Node>& data) = 0;

--- a/include/godrick/communicatorFactory.h
+++ b/include/godrick/communicatorFactory.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <memory>
+#include <godrick/communicator.h>
+
+namespace godrick 
+{
+
+std::shared_ptr<godrick::Communicator> createCommunicator(const std::string& type);
+
+} // godrick

--- a/include/godrick/mpi/communicatorMPI.h
+++ b/include/godrick/mpi/communicatorMPI.h
@@ -29,7 +29,7 @@ public:
     CommunicatorMPI() : Communicator(){}
     virtual ~CommunicatorMPI() override {}
 
-    virtual bool initFromJSON(json& data) override;
+    virtual bool initFromJSON(json& data, const std::string& taskName) override;
 
     virtual bool send(conduit::Node& data) override;
     virtual bool receive(std::vector<conduit::Node>& data) override;

--- a/include/godrick/zmq/communicatorZMQ.h
+++ b/include/godrick/zmq/communicatorZMQ.h
@@ -8,13 +8,25 @@ namespace godrick {
 
 namespace grzmq {
 
+enum class ZMQCommProtocol : uint8_t
+{
+    PUSH_PULL = 0,
+    PUB_SUB = 1
+};
+
+static std::unordered_map<std::string, ZMQCommProtocol> strToZMQCommProtocol = {
+    {"PUSH_PULL", ZMQCommProtocol::PUSH_PULL},
+    {"PUB_SUB", ZMQCommProtocol::PUB_SUB}
+};
+
+
 class CommunicatorZMQ : public Communicator 
 {
 public:
     CommunicatorZMQ() : Communicator(), m_context(1) {}
     virtual ~CommunicatorZMQ(){}
 
-    virtual bool initFromJSON(json& data) override;
+    virtual bool initFromJSON(json& data, const std::string& taskName) override;
 
     virtual bool send(conduit::Node& data) override;
     virtual bool receive(std::vector<conduit::Node>& data) override;
@@ -22,6 +34,8 @@ public:
 
 protected:
     zmq::context_t m_context;
+    ZMQCommProtocol m_protocol = ZMQCommProtocol::PUB_SUB;
+    zmq::socket_t m_socket;
 };
 
 } // zmq

--- a/include/godrick/zmq/communicatorZMQ.h
+++ b/include/godrick/zmq/communicatorZMQ.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <godrick/communicator.h>
+
+#include <zmq.hpp>
+
+namespace godrick {
+
+namespace grzmq {
+
+class CommunicatorZMQ : public Communicator 
+{
+public:
+    CommunicatorZMQ() : Communicator(), m_context(1) {}
+    virtual ~CommunicatorZMQ(){}
+
+    virtual bool initFromJSON(json& data) override;
+
+    virtual bool send(conduit::Node& data) override;
+    virtual bool receive(std::vector<conduit::Node>& data) override;
+    virtual void flush() override {}
+
+protected:
+    zmq::context_t m_context;
+};
+
+} // zmq
+
+} // godrick

--- a/python/godrick/communicator.py
+++ b/python/godrick/communicator.py
@@ -120,6 +120,11 @@ class ZMQCommunicator(Communicator):
                     raise RuntimeError("The ZMQ protocol currently only support single process tasks.")
                 self.protocolSettings["pubaddr"] = outputProcesses[0].hostname
                 self.protocolSettings["pubport"] = 50000
+            elif self.protocol == ZMQCommunicatorProtocol.PUSH_PULL:
+                if len(outputProcesses) > 1:
+                    raise RuntimeError("The ZMQ protocol currently only support single process tasks.")
+                self.protocolSettings["pushaddr"] = outputProcesses[0].hostname
+                self.protocolSettings["pushport"] = 50000
             else:
                 raise NotImplementedError("The requested ZMQ protocol is currently not supported.")
     

--- a/python/godrick/port.py
+++ b/python/godrick/port.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Port():
     def __init__(self, name:str, task) -> None:
         self.name = name
@@ -13,6 +16,9 @@ class Port():
     
     def getTaskName(self) -> str:
         return self.task.getName()
+    
+    def getTask(self):
+        return self.task
 
 class InputPort(Port):
     def __init__(self, name: str, task) -> None:

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -2,8 +2,9 @@
 
 #include <spdlog/spdlog.h>
 
-bool godrick::Communicator::initFromJSON(json& data)
+bool godrick::Communicator::initFromJSON(json& data, const std::string& taskName)
 {
+    (void)taskName;
     if(!data.contains("name"))
     {
         spdlog::error("Unable to find the name of a communicator when loading.");

--- a/src/communicatorFactory.cpp
+++ b/src/communicatorFactory.cpp
@@ -1,5 +1,4 @@
 #include <godrick/communicatorFactory.h>
-
 #ifdef GODRICK_MPI
 #include <godrick/mpi/communicatorMPI.h>
 #endif
@@ -7,10 +6,6 @@
 #include <godrick/zmq/communicatorZMQ.h>
 #endif
 
-// Forward declaration. The relevant classes are defined in their own library, not the core library
-
-
-#include <unordered_map>
 #include <spdlog/spdlog.h>
 
 std::shared_ptr<godrick::Communicator> godrick::createCommunicator(const std::string& type)

--- a/src/communicatorFactory.cpp
+++ b/src/communicatorFactory.cpp
@@ -1,0 +1,39 @@
+#include <godrick/communicatorFactory.h>
+
+#ifdef GODRICK_MPI
+#include <godrick/mpi/communicatorMPI.h>
+#endif
+#ifdef GODRICK_ZMQ
+#include <godrick/zmq/communicatorZMQ.h>
+#endif
+
+// Forward declaration. The relevant classes are defined in their own library, not the core library
+
+
+#include <unordered_map>
+#include <spdlog/spdlog.h>
+
+std::shared_ptr<godrick::Communicator> godrick::createCommunicator(const std::string& type)
+{
+    if(type.compare("MPI") == 0)
+    {
+#ifdef GODRICK_MPI
+        return std::make_shared<godrick::mpi::CommunicatorMPI>();
+#else 
+        spdlog::error("Godrick was not compiled with MPI support, unable to create a MPI communicator.");
+        return nullptr;
+#endif
+    }
+    if(type.compare("ZMQ") == 0)
+    {
+#ifdef GODRICK_ZMQ
+        return std::make_shared<godrick::grzmq::CommunicatorZMQ>();
+#else
+        spdlog::error("Godrick was not compiled with ZMQ support, unable to create a MPI communicator.");
+        return nullptr;
+#endif
+    }
+    
+    spdlog::error("Unknown communicator type {}.", type);
+    return nullptr;
+}

--- a/src/mpi/CMakeLists.txt
+++ b/src/mpi/CMakeLists.txt
@@ -17,16 +17,19 @@ target_link_libraries( ${library_MODULE}
                                 GR_project_libraries
                                 GR_project_options
                                 GR_project_warnings
-                                GodrickLib
                                 conduit::conduit_mpi
                                 MPI::MPI_CXX
                      )
-
+target_compile_definitions(${library_MODULE} 
+                            PUBLIC
+                                GODRICK_MPI)
 target_link_libraries( ${library_MODULE}
                          PRIVATE
                             GR_project_warnings
                             GR_project_options
                   )
+
+
 target_compile_features(   ${library_MODULE} PUBLIC cxx_std_20)
 
 include(GNUInstallDirs)

--- a/src/mpi/communicatorMPI.cpp
+++ b/src/mpi/communicatorMPI.cpp
@@ -6,7 +6,7 @@
 
 #include <conduit/conduit_relay_mpi.hpp>
 
-bool godrick::mpi::CommunicatorMPI::initFromJSON(json& data)
+bool godrick::mpi::CommunicatorMPI::initFromJSON(json& data, const std::string& taskName)
 {
     if(data.count("type") == 0 || data.at("type").get<std::string>().compare("MPI") != 0)
     {
@@ -15,7 +15,7 @@ bool godrick::mpi::CommunicatorMPI::initFromJSON(json& data)
     }
 
     // First initialize from the parent class 
-    if(!godrick::Communicator::initFromJSON(data))
+    if(!godrick::Communicator::initFromJSON(data, taskName))
         return false;
 
     // Get the global ranking information

--- a/src/mpi/godrickMPI.cpp
+++ b/src/mpi/godrickMPI.cpp
@@ -1,9 +1,7 @@
 #include <godrick/mpi/godrickMPI.h>
 #include <godrick/mpi/utilsMPI.h>
-
-
-//#include <godrick/mpi/communicatorMPI.h>
 #include <godrick/communicatorFactory.h>
+
 
 #include <fstream>
 #include <sstream>
@@ -99,7 +97,7 @@ bool godrick::mpi::GodrickMPI::initFromJSON(const std::string& jsonPath, const s
                     spdlog::error("Unable to create the communicator {} (something wrong in the json configuration file?).", comm["name"].get<std::string>());
                     return false;
                 }
-                commObj->initFromJSON(comm);
+                commObj->initFromJSON(comm, taskName);
 
                 // Assign the communicator to its port.
                 if(comm["inputTaskName"].get<std::string>().compare(taskName) == 0)

--- a/src/mpi/godrickMPI.cpp
+++ b/src/mpi/godrickMPI.cpp
@@ -1,7 +1,9 @@
 #include <godrick/mpi/godrickMPI.h>
 #include <godrick/mpi/utilsMPI.h>
 
-#include <godrick/mpi/communicatorMPI.h>
+
+//#include <godrick/mpi/communicatorMPI.h>
+#include <godrick/communicatorFactory.h>
 
 #include <fstream>
 #include <sstream>
@@ -83,19 +85,20 @@ bool godrick::mpi::GodrickMPI::initFromJSON(const std::string& jsonPath, const s
     // Processing the communicator
     if(data.count("communicators") > 0)
     {
+
         for(auto & comm : data["communicators"])
         {
             if(comm["inputTaskName"].get<std::string>().compare(taskName) == 0 || comm["outputTaskName"].get<std::string>().compare(taskName) == 0)
             {
                 // This communicator is associated with the local task, processing it
                 spdlog::info("Found the communicator {} associated with the local task {}.", comm["name"].get<std::string>(), taskName);
-                if(comm["type"].get<std::string>().compare("MPI") != 0)
+
+                auto commObj = godrick::createCommunicator(comm["type"].get<std::string>());
+                if(!commObj)
                 {
-                    spdlog::error("Wrong communicator type associated with the communicator. This reader can only processed MPI communicators.");
+                    spdlog::error("Unable to create the communicator {} (something wrong in the json configuration file?).", comm["name"].get<std::string>());
                     return false;
                 }
-
-                auto commObj = std::make_shared<CommunicatorMPI>();
                 commObj->initFromJSON(comm);
 
                 // Assign the communicator to its port.

--- a/src/zmq/CMakeLists.txt
+++ b/src/zmq/CMakeLists.txt
@@ -1,9 +1,8 @@
-# Build the base library
 #=======================================
-set(library_MODULE GodrickLib   )
+set(library_MODULE GodrickZMQLib   )
 #=======================================
 
-file(GLOB files "*.cpp")
+file(GLOB_RECURSE files "*.cpp")
 
 add_library( ${library_MODULE} SHARED ${files} )
 
@@ -18,7 +17,12 @@ target_link_libraries( ${library_MODULE}
                                 GR_project_libraries
                                 GR_project_options
                                 GR_project_warnings
+                                CONAN_PKG::cppzmq
                      )
+
+target_compile_definitions(${library_MODULE} 
+                     PUBLIC
+                         GODRICK_ZMQ)
 
 target_link_libraries( ${library_MODULE}
                          PRIVATE
@@ -29,12 +33,3 @@ target_compile_features(   ${library_MODULE} PUBLIC cxx_std_20)
 
 include(GNUInstallDirs)
 install(TARGETS ${library_MODULE} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-if(${GR_MPI_TRANSPORT})
-    add_subdirectory(mpi)
-    target_link_libraries(${library_MODULE} PUBLIC GodrickMPILib)
-endif()
-if(${GR_ZMQ_TRANSPORT})
-    add_subdirectory(zmq)
-    target_link_libraries(${library_MODULE} PUBLIC GodrickZMQLib)
-endif()

--- a/src/zmq/communicatorZMQ.cpp
+++ b/src/zmq/communicatorZMQ.cpp
@@ -1,19 +1,176 @@
 #include <godrick/zmq/communicatorZMQ.h>
 
-bool godrick::grzmq::CommunicatorZMQ::initFromJSON(json& data)
+#include <spdlog/spdlog.h>
+
+bool godrick::grzmq::CommunicatorZMQ::initFromJSON(json& data, const std::string& taskName)
 {
-    (void)data;
+    if(data.count("type") == 0 || data.at("type").get<std::string>().compare("ZMQ") != 0)
+    {
+        spdlog::error("Wrong communicator type associated with the communicator. This reader can only process ZMQ commuinicator.");
+        return false;
+    }
+
+    // First initialize from the parent class 
+    if(!godrick::Communicator::initFromJSON(data, taskName))
+        return false;
+
+    spdlog::info("Loading the settings for the communicator {} from the task {}.", m_name, taskName);
+    // Get socket information and protocol 
+    m_protocol = strToZMQCommProtocol.at(data.at("zmqprotocol").get<std::string>());
+    std::string receiverTask = data.at("inputTaskName").get<std::string>();
+    std::string senderTask = data.at("outputTaskName").get<std::string>();
+
+    bool isReceiver = receiverTask.compare(taskName) == 0;
+    bool isSender = senderTask.compare(taskName) == 0;
+
+    if(!isReceiver && !isSender)
+    {
+        spdlog::error("Trying to process the the communicator {} from task {}, but the task is neither the sender not the receiver. Something went wrong when processing the configuration file.", m_name, taskName);
+        return false;
+    }
+
+    switch(m_protocol)
+    {
+        case ZMQCommProtocol::PUB_SUB:
+        {
+            std::string addr = data["protocolSettings"].at("pubaddr").get<std::string>();
+            int port = data["protocolSettings"].at("pubport").get<int>();
+            std::stringstream ss;
+            ss<<"tcp://"<<addr<<":"<<port;
+            if(isReceiver)
+            {
+                m_socket = zmq::socket_t(m_context, ZMQ_SUB);
+                m_socket.connect(ss.str());
+                m_socket.set(zmq::sockopt::subscribe, "");  // We subscribe to anything
+                spdlog::info("Connecting the receiver {} to the address {}.", taskName, ss.str());
+            }
+            else
+            {
+                m_socket = zmq::socket_t(m_context, ZMQ_PUB);
+                m_socket.bind(ss.str());
+                spdlog::info("Binding the sender {} to the address {}.", taskName, ss.str());
+            }
+            return true;
+        }
+        case ZMQCommProtocol::PUSH_PULL:
+        {
+            std::string addr = data["protocolSettings"].at("pushaddr").get<std::string>();
+            int port = data["protocolSettings"].at("pushport").get<int>();
+            std::stringstream ss;
+            ss<<"tcp://"<<addr<<":"<<port;
+            if(isReceiver)
+            {
+                m_socket = zmq::socket_t(m_context, ZMQ_PULL);
+                m_socket.connect(ss.str());
+            }
+            else
+            {
+                m_socket = zmq::socket_t(m_context, ZMQ_PUSH);
+                m_socket.bind(ss.str());
+            }
+            return true;
+        }
+        default:
+        {
+            spdlog::error("Unable to process the ZMQ communication protocol {}. Either the type is unknown or not implemented yet.", data.at("zmqprotocol"));
+            return false;
+        }
+    }
+
     return false;
 }
 
 bool godrick::grzmq::CommunicatorZMQ::send(conduit::Node& data)
 {
-    (void)data;
-    return false;
+    conduit::Schema s_data_compact;
+    
+    // schema will only be valid if compact and contig
+    if( data.is_compact() && data.is_contiguous())
+    {
+        s_data_compact = data.schema();
+    }
+    else
+    {
+        data.schema().compact_to(s_data_compact);
+    }
+    
+    std::string snd_schema_json = s_data_compact.to_json();
+        
+    conduit::Schema s_msg;
+    s_msg["schema_len"].set(conduit::DataType::int64());
+    s_msg["schema"].set(conduit::DataType::char8_str(static_cast<int64_t>(snd_schema_json.size()+1)));
+    s_msg["data"].set(s_data_compact);
+    
+    // create a compact schema to use
+    conduit::Schema s_msg_compact;
+    s_msg.compact_to(s_msg_compact);
+
+    conduit::Node entry(s_msg_compact);
+    // these sets won't realloc since schemas are compatible
+    entry["schema_len"].set(static_cast<int64_t>(snd_schema_json.length()));
+    entry["schema"].set(snd_schema_json);
+    entry["data"].update(data);
+
+    size_t msg_data_size = static_cast<size_t>(entry.total_bytes_compact());
+    
+    //if(!conduit::utils::value_fits<size_t,int>(msg_data_size))
+    //{
+    //    spdlog::warn("Warning size value ( {} ) exceeds the size of MPI_Send max value ( {} )", msg_data_size, std::numeric_limits<int>::max());
+    //}
+    //zmq::message_t msg(entry.data_ptr(), static_cast<int>(msg_data_size));
+    zmq::message_t msg(entry.data_ptr(), msg_data_size);
+    m_socket.send(msg, zmq::send_flags::none); // Not doing asynchronous for now.
+    return true;
 }
 
 bool godrick::grzmq::CommunicatorZMQ::receive(std::vector<conduit::Node>& data)
 {
-    (void)data;
-    return false;
+
+    zmq::message_t msg;
+    zmq::recv_result_t result = m_socket.recv(msg, zmq::recv_flags::none);
+    if(!result.has_value())
+    {
+        spdlog::warn("The communicator {} didn't receive a message.", m_name);
+        return false;
+    }
+
+    if(result.value() == 0)
+    {
+        spdlog::warn("Empty message received by the communicator {}.", m_name);
+        return false;
+    }
+
+    data.resize(1);
+
+    conduit::Node n_buffer(conduit::DataType::uint8(static_cast<int>(msg.size())));
+
+    uint8_t *n_buff_ptr = reinterpret_cast<uint8_t*>(n_buffer.data_ptr());
+
+    conduit::Node n_msg;
+
+    // Copy the data to the conduit
+    memcpy(n_buffer.data_ptr(), msg.data(), msg.size());
+
+    // length of the schema is sent as a 64-bit signed int
+    // NOTE: we aren't using this value  ... 
+    n_msg["schema_len"].set_external(reinterpret_cast<int64_t*>(n_buff_ptr));
+    n_buff_ptr +=8;
+    // wrap the schema string
+    n_msg["schema"].set_external_char8_str(reinterpret_cast<char*>(n_buff_ptr));
+    // create the schema
+    conduit::Schema rcv_schema;
+    conduit::Generator gen(n_msg["schema"].as_char8_str());
+    gen.walk(rcv_schema);
+
+    // advance by the schema length
+    n_buff_ptr += n_msg["schema"].total_bytes_compact();
+    
+    // apply the schema to the data
+    n_msg["data"].set_external(rcv_schema,n_buff_ptr);
+    
+    // copy out to our result node
+    data[0].update(n_msg["data"]);
+
+
+    return true;
 }

--- a/src/zmq/communicatorZMQ.cpp
+++ b/src/zmq/communicatorZMQ.cpp
@@ -1,0 +1,19 @@
+#include <godrick/zmq/communicatorZMQ.h>
+
+bool godrick::grzmq::CommunicatorZMQ::initFromJSON(json& data)
+{
+    (void)data;
+    return false;
+}
+
+bool godrick::grzmq::CommunicatorZMQ::send(conduit::Node& data)
+{
+    (void)data;
+    return false;
+}
+
+bool godrick::grzmq::CommunicatorZMQ::receive(std::vector<conduit::Node>& data)
+{
+    (void)data;
+    return false;
+}

--- a/tests/cpp/data/config.ZMQPubSubWorkflow.json
+++ b/tests/cpp/data/config.ZMQPubSubWorkflow.json
@@ -1,0 +1,39 @@
+{
+    "tasks": [
+        {
+            "name": "sendpubsub",
+            "type": "MPI",
+            "inputPorts": [],
+            "outputPorts": [
+                "out"
+            ],
+            "startRank": 0,
+            "nbRanks": 1
+        },
+        {
+            "name": "receivepubsub",
+            "type": "MPI",
+            "inputPorts": [
+                "in"
+            ],
+            "outputPorts": [],
+            "startRank": 1,
+            "nbRanks": 1
+        }
+    ],
+    "communicators": [
+        {
+            "name": "myComm",
+            "type": "ZMQ",
+            "inputPortName": "in",
+            "inputTaskName": "receivepubsub",
+            "outputPortName": "out",
+            "outputTaskName": "sendpubsub",
+            "zmqprotocol": "PUB_SUB",
+            "protocolSettings": {
+                "pubaddr": "localhost",
+                "pubport": 50000
+            }
+        }
+    ]
+}

--- a/tests/cpp/data/config.ZMQPushPullWorkflow.json
+++ b/tests/cpp/data/config.ZMQPushPullWorkflow.json
@@ -1,0 +1,39 @@
+{
+    "tasks": [
+        {
+            "name": "sendpushpull",
+            "type": "MPI",
+            "inputPorts": [],
+            "outputPorts": [
+                "out"
+            ],
+            "startRank": 0,
+            "nbRanks": 1
+        },
+        {
+            "name": "receivepushpull",
+            "type": "MPI",
+            "inputPorts": [
+                "in"
+            ],
+            "outputPorts": [],
+            "startRank": 1,
+            "nbRanks": 1
+        }
+    ],
+    "communicators": [
+        {
+            "name": "myComm",
+            "type": "ZMQ",
+            "inputPortName": "in",
+            "inputTaskName": "receivepushpull",
+            "outputPortName": "out",
+            "outputTaskName": "sendpushpull",
+            "zmqprotocol": "PUSH_PULL",
+            "protocolSettings": {
+                "pushaddr": "localhost",
+                "pushport": 50000
+            }
+        }
+    ]
+}

--- a/tests/cpp/unit-zmqcomm-pubsub.cpp
+++ b/tests/cpp/unit-zmqcomm-pubsub.cpp
@@ -1,0 +1,90 @@
+#include <catch2/catch.hpp>
+
+#include <godrick/mpi/godrickMPI.h>
+#include <spdlog/spdlog.h>
+
+#include <filesystem>
+#include <chrono>
+#include <thread>
+
+SCENARIO("ZMQ transport with PUB_SUB protocol.")
+{
+    int size_world, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size_world);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if( size_world < 2 )
+    {
+        spdlog::error("Unit test zmq requires at least 2 processes." );
+        REQUIRE(false);
+        return;
+    }
+
+    if (rank >= 2)
+    {
+        // The pubsub only uses 2 processes for now but all the unit tests using MPI 
+        // have 4 processes. Ignoring the other 2.
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Finalize();
+        return;
+    }
+
+    // Check that the config file exist
+    std::string configPath = "data/config.ZMQPubSubWorkflow.json";
+    REQUIRE(std::filesystem::exists(configPath));
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    if(rank == 0)
+    {
+        // Sender code
+        std::string taskName = "sendpubsub";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+
+        // Sending the data
+        conduit::Node data;
+        uint32_t val = 10;
+        data["data"] = val;
+        data.print_detailed();
+
+        // Sending multiple messages in case the subscriber is a bit slow to connect.
+        // If the sender send a message before the receiver is ready, the message 
+        // will be sent to nobody, and the receiver will wait forever.
+        uint32_t nbSends = 5;
+        for(uint32_t i = 0; i < nbSends; ++i)
+        {
+            REQUIRE(handler.push("out", data));
+            handler.flush("out");
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+
+        // Closing the application
+        handler.close();
+    }
+    else 
+    {
+        // Receiver code
+        std::string taskName = "receivepubsub";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+
+        // Receiving the data
+        std::vector<conduit::Node> receivedData;
+        REQUIRE(handler.get("in", receivedData));
+        uint32_t nbAttempts = 0;
+        uint32_t maxAttempts = 5;
+        while(!handler.get("in", receivedData) && nbAttempts < maxAttempts)
+        {
+            nbAttempts++;
+            spdlog::warn("Failed to receive data attempt {}.", nbAttempts);
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
+        
+        // Check the data received 
+        REQUIRE(receivedData.size() == 1);
+        uint32_t val = 10;
+        REQUIRE(receivedData[0]["data"].as_uint32() == val);
+
+        // Closing the application
+        handler.close();
+    }
+}

--- a/tests/cpp/unit-zmqcomm-pushpull.cpp
+++ b/tests/cpp/unit-zmqcomm-pushpull.cpp
@@ -1,0 +1,71 @@
+#include <catch2/catch.hpp>
+
+#include <godrick/mpi/godrickMPI.h>
+#include <spdlog/spdlog.h>
+
+#include <filesystem>
+
+SCENARIO("ZMQ transport with PUSH_PULL protocol.")
+{
+    int size_world, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size_world);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if( size_world < 2 )
+    {
+        spdlog::error("Unit test zmq requires at least 2 processes." );
+        REQUIRE(false);
+        return;
+    }
+
+    if (rank >= 2)
+    {
+        // The pushpull only uses 2 processes for now but all the unit tests using MPI 
+        // have 4 processes. Ignoring the other 2.
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Finalize();
+        return;
+    }
+
+    // Check that the config file exist
+    std::string configPath = "data/config.ZMQPushPullWorkflow.json";
+    REQUIRE(std::filesystem::exists(configPath));
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    if(rank == 0)
+    {
+        // Sender code
+        std::string taskName = "sendpushpull";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+
+        // Sending the data
+        conduit::Node data;
+        uint32_t val = 10;
+        data["data"] = val;
+        data.print_detailed();
+        REQUIRE(handler.push("out", data));
+        handler.flush("out");
+
+        // Closing the application
+        handler.close();
+    }
+    else 
+    {
+        // Receiver code
+        std::string taskName = "receivepushpull";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+
+        // Receiving the data
+        std::vector<conduit::Node> receivedData;
+        REQUIRE(handler.get("in", receivedData));
+        
+        // Check the data received 
+        REQUIRE(receivedData.size() == 1);
+        uint32_t val = 10;
+        REQUIRE(receivedData[0]["data"].as_uint32() == val);
+
+        // Closing the application
+        handler.close();
+    }
+}

--- a/tests/python/test_zmqcommunicator.py
+++ b/tests/python/test_zmqcommunicator.py
@@ -1,0 +1,59 @@
+from godrick.workflow import Workflow
+from godrick.launcher import MainLauncher
+from godrick.task import MPITask, MPIPlacementPolicy
+from godrick.computeResources import ComputeCollection
+from godrick.communicator import ZMQCommunicator, ZMQCommunicatorProtocol
+
+import os
+from pathlib import Path
+import json
+
+def test_ZMQCommunicator():
+    exampleFile = os.path.join(Path(__file__).resolve().parent, "../../data/tests/singlehost.txt")
+    cluster = ComputeCollection(name="myCluster")
+    cluster.initFromHostFile(exampleFile, True)
+
+    workflow = Workflow("MPIBroadcastWorkflow")
+    partitions = cluster.splitNodesByCoreRange([1, 1])
+
+    task1 = MPITask(name="send", cmdline="bin/send --name send --config config.MPIBroadcastWorkflow.json", placementPolicy=MPIPlacementPolicy.ONETASKPERCORE)
+    task1.addOutputPort("out")
+    task1.setResources(partitions[0])
+    task2 = MPITask(name="receive", cmdline="bin/receive --name receive --config config.MPIBroadcastWorkflow.json", placementPolicy=MPIPlacementPolicy.ONETASKPERCORE)
+    task2.addInputPort("in")
+    task2.setResources(partitions[1])
+
+    comm1 = ZMQCommunicator(id="myComm", protocol=ZMQCommunicatorProtocol.PUB_SUB)
+    comm1.connectInput(task2.getInputPort("in"))
+    comm1.connectOutput(task1.getOutputPort("out"))
+
+    workflow.declareTask(task1)
+    workflow.declareTask(task2)
+    workflow.declareCommunicator(comm1)
+
+    launcher = MainLauncher()
+    launcher.generateOutputFiles(workflow=workflow)
+
+    configFile = Path(workflow.getConfigurationFile())
+    assert configFile.is_file()
+    with open(configFile) as f:
+        doc = f.read()
+        data = json.loads(doc)
+
+        # Check the data for the communicator 
+        assert "communicators" in data.keys()
+        assert len(data["communicators"]) == 1
+
+        
+        commDict = data["communicators"][0]
+        assert commDict["name"] == "myComm"
+        assert commDict["type"] == "ZMQ"
+        assert commDict["zmqprotocol"] == ZMQCommunicatorProtocol.PUB_SUB.name
+        assert commDict["inputPortName"] == "in"
+        assert commDict["inputTaskName"] == "receive"
+        assert commDict["outputPortName"] == "out"
+        assert commDict["outputTaskName"] == "send"
+        assert commDict["protocolSettings"]["pubaddr"] == "machine1"
+        assert commDict["protocolSettings"]["pubport"] == 50000
+
+    launcher.removeFiles()


### PR DESCRIPTION
Implement a push/pull and pub/sub pattern using ZMQ as possible communicators. Currently, the producer has to be a single process. This is to avoid having to deal with multiple ports on the same host. Could still happen in the case of multiple ports on the same machine.

Still to-do:
- zmq unit test for the cpp side
- Add security when processing the communicators to check that two port are not binding to the same address.