### PR TITLE
Terminate and token message added

### DIFF
--- a/examples/mpibroadcast/receive.cpp
+++ b/examples/mpibroadcast/receive.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
     }
 
     std::vector<conduit::Node> receivedData;
-    if(handler.get("in", receivedData))
+    if(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES)
     {
         if(receivedData.size() == 1)
         {   

--- a/examples/mpipartialbcastgather/receive.cpp
+++ b/examples/mpipartialbcastgather/receive.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
     }
 
     std::vector<conduit::Node> receivedData;
-    if(handler.get("in", receivedData))
+    if(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES)
     {
         spdlog::info("Received {} conduit nodes.", receivedData.size());
         for(auto & node : receivedData) 

--- a/examples/zmqpubsub/receive.cpp
+++ b/examples/zmqpubsub/receive.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
 
     std::vector<conduit::Node> receivedData;
     uint32_t nbAttempts = 0;
-    while(!handler.get("in", receivedData))
+    while(handler.get("in", receivedData) != godrick::MessageResponse::MESSAGES)
     {
         nbAttempts++;
         spdlog::warn("Failed to receive data attempt {}.", nbAttempts);

--- a/examples/zmqpushpull/receive.cpp
+++ b/examples/zmqpushpull/receive.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
     }
 
     std::vector<conduit::Node> receivedData;
-    if(handler.get("in", receivedData))
+    if(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES)
     {
         if(receivedData.size() == 1)
         {   

--- a/include/godrick/communicator.h
+++ b/include/godrick/communicator.h
@@ -11,20 +11,36 @@ using json = nlohmann::json;
 
 namespace godrick {
 
+enum class MessageResponse : uint8_t
+{
+    TOKEN = 0,      // System message type generated to unlock loops
+    TERMINATE = 1,  // System message type generated when calling close()
+    MESSAGES = 2,   // Regular messages
+    EMPTY = 3,      // Try to receive messages but nothing is available. Only used by gates
+    ERROR = 4
+};
+
 class Communicator
 {
 public:
     Communicator(){}
     virtual ~Communicator(){}
 
+    std::string getName() const { return m_name; }
+    void setName(const std::string name){ m_name = name; } 
+
+    int32_t getNbTokenLeft() const { return m_nbTokenLeft; }
+    void setNbTokenLeft(int32_t nbToken) { m_nbTokenLeft = nbToken; }
+
     virtual bool initFromJSON(json& data, const std::string& taskName);
 
     virtual bool send(conduit::Node& data) = 0;
-    virtual bool receive(std::vector<conduit::Node>& data) = 0;
+    virtual MessageResponse receive(std::vector<conduit::Node>& data) = 0;
     virtual void flush(){}
 
 protected:
     std::string m_name;
+    int32_t m_nbTokenLeft = 0;
 }; // Communicator
 
 } // godrick

--- a/include/godrick/godrick.h
+++ b/include/godrick/godrick.h
@@ -10,15 +10,6 @@
 
 namespace godrick {
 
-enum class MessageResponse : uint8_t
-{
-    TOKEN = 0,      // System message type generated to unlock loops
-    TERMINATE = 1,  // System message type generated when calling close()
-    MESSAGES = 2,   // Regular messages
-    EMPTY = 3,      // Try to receive messages but nothing is available. Only used by gates
-    ERROR = 4
-};
-
 class Godrick
 {
 
@@ -40,6 +31,7 @@ public:
 protected:
     std::unordered_map<std::string, InputPort>  m_inputPorts;
     std::unordered_map<std::string, OutputPort> m_outputPorts;
+    std::string m_taskName;
 
 }; // Godrick
 

--- a/include/godrick/godrick.h
+++ b/include/godrick/godrick.h
@@ -18,14 +18,14 @@ public:
     virtual ~Godrick(){}
     virtual bool initFromJSON(const std::string& jsonPath, const std::string& taskName);
 
-    virtual void close(){}
+    virtual void close();
 
     std::vector<std::string> getInputPortList() const;
     std::vector<std::string> getOutputPortList() const;
 
     bool push(const std::string& portName, conduit::Node& data, bool autoFlush = false) const;
     void flush(const std::string& portName);
-    bool get(const std::string& portName, std::vector<conduit::Node>& data) const;
+    bool get(const std::string& portName, std::vector<conduit::Node>& data);
 
 
 protected:

--- a/include/godrick/godrick.h
+++ b/include/godrick/godrick.h
@@ -10,6 +10,15 @@
 
 namespace godrick {
 
+enum class MessageResponse : uint8_t
+{
+    TOKEN = 0,      // System message type generated to unlock loops
+    TERMINATE = 1,  // System message type generated when calling close()
+    MESSAGES = 2,   // Regular messages
+    EMPTY = 3,      // Try to receive messages but nothing is available. Only used by gates
+    ERROR = 4
+};
+
 class Godrick
 {
 
@@ -25,7 +34,7 @@ public:
 
     bool push(const std::string& portName, conduit::Node& data, bool autoFlush = false) const;
     void flush(const std::string& portName);
-    bool get(const std::string& portName, std::vector<conduit::Node>& data);
+    MessageResponse get(const std::string& portName, std::vector<conduit::Node>& data);
 
 
 protected:

--- a/include/godrick/messageUtils.h
+++ b/include/godrick/messageUtils.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <conduit/conduit.hpp>
+
+namespace godrick {
+
+void setTerminateMessage(conduit::Node& data);
+bool isTerminateMessage(const conduit::Node& data);
+
+} // godrick

--- a/include/godrick/mpi/communicatorMPI.h
+++ b/include/godrick/mpi/communicatorMPI.h
@@ -32,7 +32,7 @@ public:
     virtual bool initFromJSON(json& data, const std::string& taskName) override;
 
     virtual bool send(conduit::Node& data) override;
-    virtual bool receive(std::vector<conduit::Node>& data) override;
+    virtual MessageResponse receive(std::vector<conduit::Node>& data) override;
     virtual void flush() override;
 
 protected:

--- a/include/godrick/port.h
+++ b/include/godrick/port.h
@@ -30,6 +30,11 @@ public:
     InputPort(const std::string& name) : Port(name){}
     virtual ~InputPort() override {}
     bool get(std::vector<conduit::Node>&  data) const;
+    void setCloseFlag(bool flag){ m_isClosed = flag; }
+    bool isClosed() const { return m_isClosed; }
+
+protected:
+    bool m_isClosed = false;
 };
 
 class OutputPort : public Port 

--- a/include/godrick/port.h
+++ b/include/godrick/port.h
@@ -29,12 +29,14 @@ class InputPort : public Port
 public:
     InputPort(const std::string& name) : Port(name){}
     virtual ~InputPort() override {}
-    bool get(std::vector<conduit::Node>&  data) const;
+    godrick::MessageResponse get(std::vector<conduit::Node>&  data);
     void setCloseFlag(bool flag){ m_isClosed = flag; }
     bool isClosed() const { return m_isClosed; }
+    virtual void addCommunicator(std::shared_ptr<Communicator> comm) override; 
 
 protected:
     bool m_isClosed = false;
+    
 };
 
 class OutputPort : public Port 

--- a/include/godrick/zmq/communicatorZMQ.h
+++ b/include/godrick/zmq/communicatorZMQ.h
@@ -29,7 +29,7 @@ public:
     virtual bool initFromJSON(json& data, const std::string& taskName) override;
 
     virtual bool send(conduit::Node& data) override;
-    virtual bool receive(std::vector<conduit::Node>& data) override;
+    virtual MessageResponse receive(std::vector<conduit::Node>& data) override;
     virtual void flush() override {}
 
 protected:

--- a/python/godrick/communicator.py
+++ b/python/godrick/communicator.py
@@ -26,10 +26,16 @@ class Communicator():
     def __init__(self, name:str, transport:CommunicatorTransportType) -> None:
         self.name = name
         self.transport = transport
+        self.nbTokens = 0
 
         self.configured = False
         self.processedByLauncher = False    # Flag used when creating the command line
                                             # This will be switched when a launcher convert the Task to command line
+
+    def setNbToken(self, nbTokens:int = 0):
+        if nbTokens < 0:
+            raise ValueError("The number of token must be a positive integer.")
+        self.nbTokens = nbTokens
 
     def getName(self) -> str:
         return self.name
@@ -40,6 +46,7 @@ class Communicator():
     def toDict(self) -> dict:
         result = {}
         result["name"] = self.name
+        result["nbTokens"] = self.nbTokens
         result["transport"] = self.transport.name
         result["configured"] = self.configured
 
@@ -48,6 +55,7 @@ class Communicator():
     def fromDict(self, data:dict, version:int) -> None:
 
         self.name = data["name"]
+        self.nbTokens = data["nbTokens"]
         self.transport = CommunicatorTransportType[data["transport"]]
         self.configured = data["configured"]
 

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -11,6 +11,8 @@ bool godrick::Communicator::initFromJSON(json& data, const std::string& taskName
         return false;
     }
 
-    m_name = data.at("name").get<std::string>();
+    m_name = data.at("name").get<std::string>(); 
+    m_nbTokenLeft = data.value("nbTokens", 0);
+
     return true;
 }

--- a/src/godrick.cpp
+++ b/src/godrick.cpp
@@ -1,4 +1,5 @@
 #include <godrick/godrick.h>
+#include <godrick/messageUtils.h>
 
 #include <algorithm>
 
@@ -58,13 +59,60 @@ void godrick::Godrick::flush(const std::string& portName)
     m_outputPorts.at(portName).flush();
 }
 
-bool godrick::Godrick::get(const std::string& portName, std::vector<conduit::Node>& data) const
+bool godrick::Godrick::get(const std::string& portName, std::vector<conduit::Node>& data)
 {
     if(m_inputPorts.count(portName) == 0)
     {
         spdlog::error("Request to get on the input port {} but the port doesn't exist.", portName);
         return false;
     }
-    else 
-        return m_inputPorts.at(portName).get(data);
+    else
+    { 
+        bool result = m_inputPorts.at(portName).get(data);
+        if(result)
+        {
+            for(auto & msg : data)
+            {
+                if(godrick::isTerminateMessage(msg))
+                {
+                    m_inputPorts.at(portName).setCloseFlag(true);
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}
+
+void godrick::Godrick::close()
+{
+    conduit::Node msg;
+    godrick::setTerminateMessage(msg);
+
+    // Send the terminate message to all the receivers of this task
+    for(auto & [k, v] : m_outputPorts)
+    {
+        spdlog::info("Pushing terminate to the port {}.", k);
+        v.push(msg);
+    }
+
+    // Make sure that all the consumers have received the message
+    for(auto & [k, v] : m_outputPorts)
+    {
+        spdlog::info("Flushing the port {}.", k);
+        v.flush();
+    }
+
+    // For every input port, wait to receive a message if the port is not already closed.
+    // This is to ensure that in case of cycle, all the components have received the close 
+    // message before exiting the program.
+    for(auto & [k, v] : m_inputPorts)
+    {
+        spdlog::info("Waiting for a message on port {}", k);
+        std::vector<conduit::Node> tmp;
+        if(!v.isClosed())
+            v.get(tmp); 
+    }
+    spdlog::info("Close completed.");
 }

--- a/src/godrick.cpp
+++ b/src/godrick.cpp
@@ -59,12 +59,12 @@ void godrick::Godrick::flush(const std::string& portName)
     m_outputPorts.at(portName).flush();
 }
 
-bool godrick::Godrick::get(const std::string& portName, std::vector<conduit::Node>& data)
+godrick::MessageResponse godrick::Godrick::get(const std::string& portName, std::vector<conduit::Node>& data)
 {
     if(m_inputPorts.count(portName) == 0)
     {
         spdlog::error("Request to get on the input port {} but the port doesn't exist.", portName);
-        return false;
+        return MessageResponse::ERROR;
     }
     else
     { 
@@ -76,12 +76,14 @@ bool godrick::Godrick::get(const std::string& portName, std::vector<conduit::Nod
                 if(godrick::isTerminateMessage(msg))
                 {
                     m_inputPorts.at(portName).setCloseFlag(true);
-                    return false;
+                    return MessageResponse::TERMINATE;
                 }
             }
         }
+        else
+            return MessageResponse::EMPTY;
 
-        return true;
+        return MessageResponse::MESSAGES;
     }
 }
 

--- a/src/godrick.cpp
+++ b/src/godrick.cpp
@@ -68,8 +68,8 @@ godrick::MessageResponse godrick::Godrick::get(const std::string& portName, std:
     }
     else
     { 
-        bool result = m_inputPorts.at(portName).get(data);
-        if(result)
+        godrick::MessageResponse result = m_inputPorts.at(portName).get(data);
+        if(result == godrick::MessageResponse::MESSAGES)
         {
             for(auto & msg : data)
             {
@@ -81,7 +81,7 @@ godrick::MessageResponse godrick::Godrick::get(const std::string& portName, std:
             }
         }
         else
-            return MessageResponse::EMPTY;
+            return result;
 
         return MessageResponse::MESSAGES;
     }
@@ -95,14 +95,14 @@ void godrick::Godrick::close()
     // Send the terminate message to all the receivers of this task
     for(auto & [k, v] : m_outputPorts)
     {
-        spdlog::info("Pushing terminate to the port {}.", k);
+        spdlog::trace("Task {} pushing terminate to the port {}.", m_taskName, k);
         v.push(msg);
     }
 
     // Make sure that all the consumers have received the message
     for(auto & [k, v] : m_outputPorts)
     {
-        spdlog::info("Flushing the port {}.", k);
+        spdlog::trace("Task {} flushing the port {}.", m_taskName, k);
         v.flush();
     }
 
@@ -111,10 +111,10 @@ void godrick::Godrick::close()
     // message before exiting the program.
     for(auto & [k, v] : m_inputPorts)
     {
-        spdlog::info("Waiting for a message on port {}", k);
+        spdlog::trace("Task {} waiting for a message on port {}", m_taskName, k);
         std::vector<conduit::Node> tmp;
         if(!v.isClosed())
             v.get(tmp); 
     }
-    spdlog::info("Close completed.");
+    spdlog::trace("Task {} Close completed.", m_taskName);
 }

--- a/src/messageUtils.cpp
+++ b/src/messageUtils.cpp
@@ -1,0 +1,13 @@
+#include <godrick/messageUtils.h>
+
+void godrick::setTerminateMessage(conduit::Node& data)
+{
+    uint8_t val = 0;
+    data["godrick"]["terminate"] = val;
+    return;
+}
+
+bool godrick::isTerminateMessage(const conduit::Node& data)
+{
+    return data.has_path("godrick/terminate");
+}

--- a/src/mpi/communicatorMPI.cpp
+++ b/src/mpi/communicatorMPI.cpp
@@ -125,14 +125,24 @@ bool godrick::mpi::CommunicatorMPI::send(conduit::Node& data)
     return m_protocolImpl->send(data);
 }
 
-bool godrick::mpi::CommunicatorMPI::receive(std::vector<conduit::Node>& data)
+godrick::MessageResponse godrick::mpi::CommunicatorMPI::receive(std::vector<conduit::Node>& data)
 {
     if(!m_protocolImpl)
     {
         spdlog::error("The protocol implementation is not instanciated.");
-        return false;
+        return godrick::MessageResponse::ERROR;
     }
-    return m_protocolImpl->receive(data);
+
+    if(m_nbTokenLeft > 0)
+    {
+        m_nbTokenLeft -= 1;
+        return godrick::MessageResponse::TOKEN;
+    }
+    
+    if(m_protocolImpl->receive(data))
+        return godrick::MessageResponse::MESSAGES;
+    else
+        return godrick::MessageResponse::ERROR;
 }
 
 void godrick::mpi::CommunicatorMPI::flush()

--- a/src/mpi/godrickMPI.cpp
+++ b/src/mpi/godrickMPI.cpp
@@ -156,6 +156,9 @@ bool godrick::mpi::GodrickMPI::initMPIInfo(int startRank, int nbRanks)
 
 void godrick::mpi::GodrickMPI::close()
 {
+    // Handle the terminate message first
+    Godrick::close();
+
     MPI_Barrier(MPI_COMM_WORLD);
     MPI_Finalize();
 }

--- a/src/mpi/godrickMPI.cpp
+++ b/src/mpi/godrickMPI.cpp
@@ -53,6 +53,7 @@ bool godrick::mpi::GodrickMPI::initFromJSON(const std::string& jsonPath, const s
         if(name.compare(taskName) != 0)
             continue;
         spdlog::info("Found the task information for the current task.");
+        m_taskName = name;
         auto taskType = task.at("type").get<std::string>();
         if(taskType.compare("MPI") != 0)
         {

--- a/src/mpi/partialBcastGatherMPI.cpp
+++ b/src/mpi/partialBcastGatherMPI.cpp
@@ -131,7 +131,7 @@ bool godrick::mpi::PartialBCastGatherProtocolImplMPI::send(conduit::Node& data)
                     m_sentMsgID,
                     m_localComm,
                     &entry.requests.back());
-        spdlog::info("Sending schema from {} to {}.", m_localRank, dest);
+        spdlog::trace("Sending schema from {} to {}.", m_localRank, dest);
     }
     m_sentMsgID = (m_sentMsgID == INT_MAX ? 0 : m_sentMsgID + 1);
 
@@ -144,7 +144,7 @@ bool godrick::mpi::PartialBCastGatherProtocolImplMPI::receive(std::vector<condui
 
     // Prepare the data 
     data.resize(static_cast<size_t>(m_nbExpectedReception));
-    spdlog::info("Rank {} preparing to receive {} node.", m_localRank, m_nbExpectedReception);
+    spdlog::trace("Rank {} preparing to receive {} node.", m_localRank, m_nbExpectedReception);
     for(int i = 0; i < m_nbExpectedReception; ++i)
     {
         MPI_Status status;

--- a/src/port.cpp
+++ b/src/port.cpp
@@ -1,5 +1,7 @@
 #include <godrick/port.h>
 
+#include <stdexcept>
+
 bool godrick::OutputPort::push(conduit::Node& data) const
 {
     bool result = true;
@@ -15,11 +17,23 @@ void godrick::OutputPort::flush() const
         comm->flush();
 }
 
-bool godrick::InputPort::get(std::vector<conduit::Node>&  data) const
-{
-    bool result = true;
-    for(const auto & comm : m_communicators)
-        result &= comm->receive(data);
+void godrick::InputPort::addCommunicator(std::shared_ptr<Communicator> comm)
+{ 
+    if(m_communicators.size() > 0)
+        throw std::invalid_argument("Input port can only accept a single communicator.");
+    m_communicators.push_back(comm); 
+}
 
-    return result;
+godrick::MessageResponse godrick::InputPort::get(std::vector<conduit::Node>&  data)
+{
+    //bool result = true;
+    //for(const auto & comm : m_communicators)
+    //    result &= comm->receive(data);
+    //
+    //return result;
+    if(m_communicators.empty())
+        return godrick::MessageResponse::EMPTY;
+    else
+        // Input ports only have a single communicator, accessing it directly
+        return m_communicators[0]->receive(data);
 }

--- a/src/zmq/communicatorZMQ.cpp
+++ b/src/zmq/communicatorZMQ.cpp
@@ -177,21 +177,27 @@ bool godrick::grzmq::CommunicatorZMQ::send(conduit::Node& data)
     return true;
 }
 
-bool godrick::grzmq::CommunicatorZMQ::receive(std::vector<conduit::Node>& data)
+godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receive(std::vector<conduit::Node>& data)
 {
-
+    if(m_nbTokenLeft > 0)
+    {
+        m_nbTokenLeft -= 1;
+        return godrick::MessageResponse::TOKEN;
+    }
+    
     zmq::message_t msg;
     zmq::recv_result_t result = m_socket.recv(msg, zmq::recv_flags::none);
     if(!result.has_value())
     {
         spdlog::warn("The communicator {} didn't receive a message.", m_name);
-        return false;
+        return godrick::MessageResponse::EMPTY;
     }
 
+    // For all intended purposes, not receiving message or receiving an empty message
     if(result.value() == 0)
     {
         spdlog::warn("Empty message received by the communicator {}.", m_name);
-        return false;
+        return godrick::MessageResponse::EMPTY;
     }
 
     data.resize(1);
@@ -226,5 +232,5 @@ bool godrick::grzmq::CommunicatorZMQ::receive(std::vector<conduit::Node>& data)
     data[0].update(n_msg["data"]);
 
 
-    return true;
+    return godrick::MessageResponse::MESSAGES;
 }

--- a/tests/cpp/unit-mpicomm-broadcast.cpp
+++ b/tests/cpp/unit-mpicomm-broadcast.cpp
@@ -49,7 +49,7 @@ SCENARIO("MPI transport with Broadcast protocol.")
 
         // Receiving the data
         std::vector<conduit::Node> receivedData;
-        REQUIRE(handler.get("in", receivedData));
+        REQUIRE(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES);
         
         // Check the data received 
         REQUIRE(receivedData.size() == 1);

--- a/tests/cpp/unit-mpicomm-partial-bcast.cpp
+++ b/tests/cpp/unit-mpicomm-partial-bcast.cpp
@@ -57,7 +57,7 @@ SCENARIO("MPI transport with Partial Broadcast protocol.")
 
         // Receiving the data
         std::vector<conduit::Node> receivedData;
-        REQUIRE(handler.get("in", receivedData));
+        REQUIRE(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES);
         
         // Check the data received 
         REQUIRE(receivedData.size() == 1);
@@ -66,7 +66,7 @@ SCENARIO("MPI transport with Partial Broadcast protocol.")
 
         // Receive the second data
         receivedData.clear();
-        REQUIRE(handler.get("in", receivedData));
+        REQUIRE(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES);
 
         // Check the data received 
         REQUIRE(receivedData.size() == 1);

--- a/tests/cpp/unit-mpicomm-partial-gather.cpp
+++ b/tests/cpp/unit-mpicomm-partial-gather.cpp
@@ -49,7 +49,7 @@ SCENARIO("MPI transport with Partial Gather protocol.")
 
         // Receiving the data
         std::vector<conduit::Node> receivedData;
-        REQUIRE(handler.get("in", receivedData));
+        REQUIRE(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES);
         
         // Check the data received 
         REQUIRE(receivedData.size() == 3);

--- a/tests/cpp/unit-zmqcomm-pubsub.cpp
+++ b/tests/cpp/unit-zmqcomm-pubsub.cpp
@@ -69,10 +69,10 @@ SCENARIO("ZMQ transport with PUB_SUB protocol.")
 
         // Receiving the data
         std::vector<conduit::Node> receivedData;
-        REQUIRE(handler.get("in", receivedData));
+        REQUIRE(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES);
         uint32_t nbAttempts = 0;
         uint32_t maxAttempts = 5;
-        while(!handler.get("in", receivedData) && nbAttempts < maxAttempts)
+        while(handler.get("in", receivedData)  != godrick::MessageResponse::MESSAGES && nbAttempts < maxAttempts)
         {
             nbAttempts++;
             spdlog::warn("Failed to receive data attempt {}.", nbAttempts);

--- a/tests/cpp/unit-zmqcomm-pushpull.cpp
+++ b/tests/cpp/unit-zmqcomm-pushpull.cpp
@@ -58,7 +58,7 @@ SCENARIO("ZMQ transport with PUSH_PULL protocol.")
 
         // Receiving the data
         std::vector<conduit::Node> receivedData;
-        REQUIRE(handler.get("in", receivedData));
+        REQUIRE(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES);
         
         // Check the data received 
         REQUIRE(receivedData.size() == 1);


### PR DESCRIPTION
Consolidate the return of the get function to have better return values. Introduce the terminate function to propagate a clean termination message. Add support for tokens to allow loops in the workflow.

Closes #12
Closes #11 