### PR TITLE
JSON format support for gates

### DIFF
--- a/include/godrick/communicator.h
+++ b/include/godrick/communicator.h
@@ -20,6 +20,20 @@ enum class MessageResponse : uint8_t
     ERROR = 4
 };
 
+enum class MessageFormat : uint8_t
+{
+    CONDUIT = 0,    // Native conduit format
+    JSON = 1,       // JSON format converted from conduit
+    BSON = 2        // Binary json format
+};
+
+// Conversion table, must match the names from CommunicatorMessageFormat in communicator.py
+static std::unordered_map<std::string, MessageFormat> strToMessageFormat = {
+    {"MSG_FORMAT_CONDUIT", MessageFormat::CONDUIT},
+    {"MSG_FORMAT_JSON", MessageFormat::JSON},
+    {"MSG_FORMAT_BSON", MessageFormat::BSON}
+};
+
 class Communicator
 {
 public:
@@ -41,6 +55,7 @@ public:
 protected:
     std::string m_name;
     int32_t m_nbTokenLeft = 0;
+    MessageFormat m_msgFormat = MessageFormat::CONDUIT;
 }; // Communicator
 
 } // godrick

--- a/include/godrick/zmq/communicatorZMQ.h
+++ b/include/godrick/zmq/communicatorZMQ.h
@@ -33,6 +33,13 @@ public:
     virtual void flush() override {}
 
 protected:
+    bool sendConduitFormat(conduit::Node& data);
+    bool sendJSONFormat(conduit::Node& data);
+    bool sendBSONFormat(conduit::Node& data);
+    MessageResponse receiveConduitFormat(std::vector<conduit::Node>& data, zmq::message_t& msg);
+    MessageResponse receiveJSONFormat(std::vector<conduit::Node>& data, zmq::message_t& msg);
+    MessageResponse receiveBSONFormat(std::vector<conduit::Node>& data, zmq::message_t& msg);
+
     zmq::context_t m_context;
     ZMQCommProtocol m_protocol = ZMQCommProtocol::PUB_SUB;
     zmq::socket_t m_socket;

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -13,6 +13,14 @@ bool godrick::Communicator::initFromJSON(json& data, const std::string& taskName
 
     m_name = data.at("name").get<std::string>(); 
     m_nbTokenLeft = data.value("nbTokens", 0);
+    auto msgFormat = data.at("format").get<std::string>();
+    if(!strToMessageFormat.contains(msgFormat))
+    {
+        spdlog::error("Unknown message format {} received for the Communicator {}. Choose a supported message format.", msgFormat, m_name);
+        return false;
+    }
+    m_msgFormat = strToMessageFormat.at(msgFormat);
+
 
     return true;
 }

--- a/src/mpi/communicatorMPI.cpp
+++ b/src/mpi/communicatorMPI.cpp
@@ -18,6 +18,12 @@ bool godrick::mpi::CommunicatorMPI::initFromJSON(json& data, const std::string& 
     if(!godrick::Communicator::initFromJSON(data, taskName))
         return false;
 
+    if(m_msgFormat != MessageFormat::CONDUIT)
+    {
+        spdlog::error("The CommunicatorMPI only support CONDUIT as message format.");
+        return false;
+    }
+
     // Get the global ranking information
     m_globalInStartRank     = data.at("inStartRank").get<int>();        // Rank of the INPUT PORT = destination
     m_globalInSize          = data.at("inSize").get<int>();

--- a/src/zmq/communicatorZMQ.cpp
+++ b/src/zmq/communicatorZMQ.cpp
@@ -215,9 +215,11 @@ bool godrick::grzmq::CommunicatorZMQ::sendConduitFormat(conduit::Node& data)
 
 bool godrick::grzmq::CommunicatorZMQ::sendJSONFormat(conduit::Node& data)
 {
-    (void)data;
-    spdlog::error("The method sendJSONFormat is not implemented yet.");
-    return false;
+    auto jsonContent = data.to_json();
+
+    zmq::message_t msg(jsonContent.c_str(), jsonContent.size());
+    m_socket.send(msg, zmq::send_flags::none); // Not doing asynchronous for now.
+    return true;
 }
 
 bool godrick::grzmq::CommunicatorZMQ::sendBSONFormat(conduit::Node& data)
@@ -312,10 +314,11 @@ godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receiveConduitFormat(s
 
 godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receiveJSONFormat(std::vector<conduit::Node>& data, zmq::message_t& msg)
 {
-    (void)data;
-    (void)msg;
-    spdlog::error("The method receiveJSONFormat is not implemented yet.");
-    return godrick::MessageResponse::ERROR;
+
+    std::string msgJSON(static_cast<char*>(msg.data()), msg.size());
+
+    data[0].parse(msgJSON, "json");
+    return godrick::MessageResponse::MESSAGES;
 }
 
 godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receiveBSONFormat(std::vector<conduit::Node>& data, zmq::message_t& msg)

--- a/src/zmq/communicatorZMQ.cpp
+++ b/src/zmq/communicatorZMQ.cpp
@@ -148,6 +148,30 @@ bool godrick::grzmq::CommunicatorZMQ::initFromJSON(json& data, const std::string
 
 bool godrick::grzmq::CommunicatorZMQ::send(conduit::Node& data)
 {
+    switch (m_msgFormat)
+    {
+        case godrick::MessageFormat::CONDUIT:
+        {
+            return sendConduitFormat(data);
+        }
+        case godrick::MessageFormat::JSON:
+        {
+            return sendJSONFormat(data);
+        }
+        case godrick::MessageFormat::BSON:
+        {
+            return sendBSONFormat(data);
+        }
+        default:
+        {
+            spdlog::error("Unknown message format requested when sending.");
+            return false;
+        }
+    }
+}
+
+bool godrick::grzmq::CommunicatorZMQ::sendConduitFormat(conduit::Node& data)
+{
     conduit::Schema s_data_compact;
     
     // schema will only be valid if compact and contig
@@ -189,6 +213,20 @@ bool godrick::grzmq::CommunicatorZMQ::send(conduit::Node& data)
     return true;
 }
 
+bool godrick::grzmq::CommunicatorZMQ::sendJSONFormat(conduit::Node& data)
+{
+    (void)data;
+    spdlog::error("The method sendJSONFormat is not implemented yet.");
+    return false;
+}
+
+bool godrick::grzmq::CommunicatorZMQ::sendBSONFormat(conduit::Node& data)
+{
+    (void)data;
+    spdlog::error("The method sendBSONFormat is not implemented yet.");
+    return false;
+}
+
 godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receive(std::vector<conduit::Node>& data)
 {
     if(m_nbTokenLeft > 0)
@@ -213,7 +251,32 @@ godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receive(std::vector<co
     }
 
     data.resize(1);
+    
+    switch(m_msgFormat)
+    {
+        case godrick::MessageFormat::CONDUIT:
+        {
+            return receiveConduitFormat(data, msg);
+        }
+        case godrick::MessageFormat::JSON:
+        {
+            return receiveJSONFormat(data, msg);
+        }
+        case godrick::MessageFormat::BSON:
+        {
+            return receiveBSONFormat(data, msg);
+        }
+        default:
+        {
+            spdlog::error("Unknown message format requested.");
+            data.clear();
+            return godrick::MessageResponse::ERROR;
+        }
+    }
+}
 
+godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receiveConduitFormat(std::vector<conduit::Node>& data, zmq::message_t& msg)
+{
     conduit::Node n_buffer(conduit::DataType::uint8(static_cast<int>(msg.size())));
 
     uint8_t *n_buff_ptr = reinterpret_cast<uint8_t*>(n_buffer.data_ptr());
@@ -245,4 +308,20 @@ godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receive(std::vector<co
 
 
     return godrick::MessageResponse::MESSAGES;
+}
+
+godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receiveJSONFormat(std::vector<conduit::Node>& data, zmq::message_t& msg)
+{
+    (void)data;
+    (void)msg;
+    spdlog::error("The method receiveJSONFormat is not implemented yet.");
+    return godrick::MessageResponse::ERROR;
+}
+
+godrick::MessageResponse godrick::grzmq::CommunicatorZMQ::receiveBSONFormat(std::vector<conduit::Node>& data, zmq::message_t& msg)
+{
+    (void)data;
+    (void)msg;
+    spdlog::error("The method receiveBSONFormat is not implemented yet.");
+    return godrick::MessageResponse::ERROR;
 }

--- a/tests/cpp/data/config.MPIBroadcastWorkflow.json
+++ b/tests/cpp/data/config.MPIBroadcastWorkflow.json
@@ -45,7 +45,8 @@
             "inSize": 3,
             "outStartRank": 0,
             "outSize": 1,
-            "mpiprotocol": "BROADCAST"
+            "mpiprotocol": "BROADCAST",
+            "format": "MSG_FORMAT_CONDUIT"
         }
     ]
 }

--- a/tests/cpp/data/config.MPIPartialBcastWorkflow.json
+++ b/tests/cpp/data/config.MPIPartialBcastWorkflow.json
@@ -33,7 +33,8 @@
             "inSize": 3,
             "outStartRank": 0,
             "outSize": 1,
-            "mpiprotocol": "PARTIAL_BCAST_GATHER"
+            "mpiprotocol": "PARTIAL_BCAST_GATHER",
+            "format": "MSG_FORMAT_CONDUIT"
         }
     ]
 }

--- a/tests/cpp/data/config.MPIPartialGatherWorkflow.json
+++ b/tests/cpp/data/config.MPIPartialGatherWorkflow.json
@@ -33,7 +33,8 @@
             "inSize": 1,
             "outStartRank": 0,
             "outSize": 3,
-            "mpiprotocol": "PARTIAL_BCAST_GATHER"
+            "mpiprotocol": "PARTIAL_BCAST_GATHER",
+            "format": "MSG_FORMAT_CONDUIT"
         }
     ]
 }

--- a/tests/cpp/data/config.ZMQJSONPushPullWorkflow.json
+++ b/tests/cpp/data/config.ZMQJSONPushPullWorkflow.json
@@ -1,0 +1,42 @@
+{
+    "tasks": [
+        {
+            "name": "sendpushpull",
+            "type": "MPI",
+            "inputPorts": [],
+            "outputPorts": [
+                "out"
+            ],
+            "startRank": 0,
+            "nbRanks": 1
+        },
+        {
+            "name": "receivepushpull",
+            "type": "MPI",
+            "inputPorts": [
+                "in"
+            ],
+            "outputPorts": [],
+            "startRank": 1,
+            "nbRanks": 1
+        }
+    ],
+    "communicators": [
+        {
+            "name": "myComm",
+            "transport": "ZMQ",
+            "open": "CLOSED",
+            "inputPortName": "in",
+            "inputTaskName": "receivepushpull",
+            "outputPortName": "out",
+            "outputTaskName": "sendpushpull",
+            "zmqprotocol": "PUSH_PULL",
+            "format": "MSG_FORMAT_JSON",
+            "protocolSettings": {
+                "addr": "localhost",
+                "port": 50000,
+                "bindingside": "ZMQ_BIND_SENDER"
+            }
+        }
+    ]
+}

--- a/tests/cpp/data/config.ZMQPubSubWorkflow.json
+++ b/tests/cpp/data/config.ZMQPubSubWorkflow.json
@@ -31,6 +31,7 @@
             "outputPortName": "out",
             "outputTaskName": "sendpubsub",
             "zmqprotocol": "PUB_SUB",
+            "format": "MSG_FORMAT_CONDUIT",
             "protocolSettings": {
                 "addr": "localhost",
                 "port": 50000,

--- a/tests/cpp/data/config.ZMQPushPullWorkflow.json
+++ b/tests/cpp/data/config.ZMQPushPullWorkflow.json
@@ -31,6 +31,7 @@
             "outputPortName": "out",
             "outputTaskName": "sendpushpull",
             "zmqprotocol": "PUSH_PULL",
+            "format": "MSG_FORMAT_CONDUIT",
             "protocolSettings": {
                 "addr": "localhost",
                 "port": 50000,

--- a/tests/cpp/unit-zmqcomm-json-manual-pushpull.cpp
+++ b/tests/cpp/unit-zmqcomm-json-manual-pushpull.cpp
@@ -1,0 +1,87 @@
+#include <catch2/catch.hpp>
+
+#include <godrick/mpi/godrickMPI.h>
+#include <spdlog/spdlog.h>
+
+#include <zmq.hpp>
+
+#include <filesystem>
+
+SCENARIO("ZMQ transport with JSON Format and PUSH_PULL protocol on sender only. Received done manually.")
+{
+    int size_world, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size_world);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if( size_world < 2 )
+    {
+        spdlog::error("Unit test zmq requires at least 2 processes." );
+        REQUIRE(false);
+        return;
+    }
+
+    if (rank >= 2)
+    {
+        // The pushpull only uses 2 processes for now but all the unit tests using MPI 
+        // have 4 processes. Ignoring the other 2.
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Finalize();
+        return;
+    }
+
+    // Check that the config file exist
+    std::string configPath = "data/config.ZMQJSONPushPullWorkflow.json";
+    REQUIRE(std::filesystem::exists(configPath));
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    if(rank == 0)
+    {
+        // Sender code
+        std::string taskName = "sendpushpull";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+
+        // Sending the data
+        conduit::Node data;
+        uint32_t val = 10;
+        data["data"] = val;
+        data.print_detailed();
+        REQUIRE(handler.push("out", data));
+        handler.flush("out");
+
+        // Closing the application
+        handler.close();
+    }
+    else 
+    {
+        // Receiver code
+
+        // Manually get the data
+        std::string addr = "localhost";
+        uint32_t port = 50000;
+        std::stringstream ss;
+        ss<<"tcp://"<<addr<<":"<<port;
+
+        zmq::context_t context(1);
+        auto socket = zmq::socket_t(context, ZMQ_PULL);
+        socket.connect(ss.str());
+
+        zmq::message_t msg;
+        zmq::recv_result_t result = socket.recv(msg, zmq::recv_flags::none);
+
+        REQUIRE(result.has_value());
+        REQUIRE(result.value() != 0);
+
+        std::string msgJSON(static_cast<char*>(msg.data()), msg.size());
+
+        nlohmann::json data = json::parse(msgJSON);
+        spdlog::info("{}", msgJSON);
+        REQUIRE(data["data"].get<uint32_t>() == 10);
+
+
+
+        // Closing the application
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Finalize();
+    }
+}

--- a/tests/cpp/unit-zmqcomm-json-pushpull.cpp
+++ b/tests/cpp/unit-zmqcomm-json-pushpull.cpp
@@ -1,0 +1,76 @@
+#include <catch2/catch.hpp>
+
+#include <godrick/mpi/godrickMPI.h>
+#include <spdlog/spdlog.h>
+
+#include <zmq.hpp>
+
+#include <filesystem>
+
+SCENARIO("ZMQ transport with JSON Format and PUSH_PULL protocol.")
+{
+    int size_world, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size_world);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if( size_world < 2 )
+    {
+        spdlog::error("Unit test zmq requires at least 2 processes." );
+        REQUIRE(false);
+        return;
+    }
+
+    if (rank >= 2)
+    {
+        // The pushpull only uses 2 processes for now but all the unit tests using MPI 
+        // have 4 processes. Ignoring the other 2.
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Finalize();
+        return;
+    }
+
+    // Check that the config file exist
+    std::string configPath = "data/config.ZMQJSONPushPullWorkflow.json";
+    REQUIRE(std::filesystem::exists(configPath));
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    if(rank == 0)
+    {
+        // Sender code
+        std::string taskName = "sendpushpull";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+
+        // Sending the data
+        conduit::Node data;
+        uint32_t val = 10;
+        data["data"] = val;
+        data.print_detailed();
+        REQUIRE(handler.push("out", data));
+        handler.flush("out");
+
+        // Closing the application
+        handler.close();
+    }
+    else 
+    {
+        // Receiver code
+        std::string taskName = "receivepushpull";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+
+        // Receiving the data
+        std::vector<conduit::Node> receivedData;
+        REQUIRE(handler.get("in", receivedData) == godrick::MessageResponse::MESSAGES);
+        
+        // Check the data received 
+        REQUIRE(receivedData.size() == 1);
+        uint32_t val = 10;
+        // Conduit try to guess the type when reading from JSON but won't get the exact same type as the origin
+        // Preserving the original type is probably only possible by using the json conduit format (not simple json format)
+        // The JSON format is just meant to be used to communicate with outside application where exact type doesn't really matter
+        REQUIRE(receivedData[0]["data"].as_int64() == val); 
+
+        // Closing the application
+        handler.close();
+    }
+}


### PR DESCRIPTION
Add the possibility for gates to offert different format for messages (conduit, json, bson). BSON is currently not supported, will be done in another branch. Made the structure extensible to be able to add more formats in the future.
The format should probably be used only for gates where the message types may not be as important. 
Close #16 