### PR TITLE
ZMQ non blocking

### DIFF
--- a/include/godrick/zmq/communicatorZMQ.h
+++ b/include/godrick/zmq/communicatorZMQ.h
@@ -43,6 +43,7 @@ protected:
     zmq::context_t m_context;
     ZMQCommProtocol m_protocol = ZMQCommProtocol::PUB_SUB;
     zmq::socket_t m_socket;
+    bool m_nowait = false;
 };
 
 } // zmq

--- a/tests/cpp/data/config.ZMQPushPullWorkflowNoWait.json
+++ b/tests/cpp/data/config.ZMQPushPullWorkflowNoWait.json
@@ -1,0 +1,43 @@
+{
+    "tasks": [
+        {
+            "name": "sendpushpull",
+            "type": "MPI",
+            "inputPorts": [],
+            "outputPorts": [
+                "out"
+            ],
+            "startRank": 0,
+            "nbRanks": 1
+        },
+        {
+            "name": "receivepushpull",
+            "type": "MPI",
+            "inputPorts": [
+                "in"
+            ],
+            "outputPorts": [],
+            "startRank": 1,
+            "nbRanks": 1
+        }
+    ],
+    "communicators": [
+        {
+            "name": "myComm",
+            "transport": "ZMQ",
+            "open": "CLOSED",
+            "inputPortName": "in",
+            "inputTaskName": "receivepushpull",
+            "outputPortName": "out",
+            "outputTaskName": "sendpushpull",
+            "zmqprotocol": "PUSH_PULL",
+            "format": "MSG_FORMAT_CONDUIT",
+            "nonblocking": true,
+            "protocolSettings": {
+                "addr": "localhost",
+                "port": 50000,
+                "bindingside": "ZMQ_BIND_SENDER"
+            }
+        }
+    ]
+}

--- a/tests/cpp/unit-zmqcomm-pushpull-nowait.cpp
+++ b/tests/cpp/unit-zmqcomm-pushpull-nowait.cpp
@@ -1,0 +1,70 @@
+#include <catch2/catch.hpp>
+
+#include <godrick/mpi/godrickMPI.h>
+#include <spdlog/spdlog.h>
+
+#include <filesystem>
+
+SCENARIO("ZMQ transport with PUSH_PULL protocol and no wait.")
+{
+    int size_world, rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &size_world);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if( size_world < 2 )
+    {
+        spdlog::error("Unit test zmq requires at least 2 processes." );
+        REQUIRE(false);
+        return;
+    }
+
+    if (rank >= 2)
+    {
+        // The pushpull only uses 2 processes for now but all the unit tests using MPI 
+        // have 4 processes. Ignoring the other 2. 
+
+        // Calling Barrier to unlock the unit test barrier
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        //Calling Barrier to unlok the handler.close()
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Finalize();
+        return;
+    }
+
+    // Check that the config file exist
+    std::string configPath = "data/config.ZMQPushPullWorkflowNoWait.json";
+    REQUIRE(std::filesystem::exists(configPath));
+
+    auto handler = godrick::mpi::GodrickMPI();
+
+    if(rank == 0)
+    {
+        // Sender code
+        std::string taskName = "sendpushpull";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+        
+        // Barrier to prevent the receiver to receive the terminate message
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Closing the application
+        handler.close();
+    }
+    else 
+    {
+        // Receiver code
+        std::string taskName = "receivepushpull";
+        REQUIRE(handler.initFromJSON(configPath, taskName));
+
+        // Receiving the data
+        std::vector<conduit::Node> receivedData;
+        spdlog::info("Waiting for data on rank {}", rank);
+        REQUIRE(handler.get("in", receivedData) == godrick::MessageResponse::EMPTY);
+
+        // Barrier to prevent the receiver to receive the terminate message
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Closing the application
+        handler.close();
+    }
+}

--- a/tests/python/test_zmqgate.py
+++ b/tests/python/test_zmqgate.py
@@ -25,7 +25,7 @@ def test_ZMQGateCommunicator():
 
     gateSender = ZMQGateCommunicator(name="senderSide", side=CommunicatorGateSideFlag.OPEN_SENDER, bindingSide=ZMQBindingSide.ZMQ_BIND_SENDER)
     gateSender.connectToOutputPort(task1.getOutputPort("out"))
-    gateReceiver = ZMQGateCommunicator(name="receiverSide", side=CommunicatorGateSideFlag.OPEN_RECEIVER, bindingSide=ZMQBindingSide.ZMQ_BIND_SENDER)
+    gateReceiver = ZMQGateCommunicator(name="receiverSide", side=CommunicatorGateSideFlag.OPEN_RECEIVER, bindingSide=ZMQBindingSide.ZMQ_BIND_SENDER, nonblocking=True)
     gateReceiver.connectToInputPort(task2.getInputPort("in"))
 
     gateSender.connectToGate(gateReceiver)
@@ -58,6 +58,10 @@ def test_ZMQGateCommunicator():
             assert commDict["protocolSettings"]["addr"] == "machine1"
             assert commDict["protocolSettings"]["port"] == 50000
             assert commDict["protocolSettings"]["bindingside"] == ZMQBindingSide.ZMQ_BIND_SENDER.name
+            if commDict["name"] == "senderSide":
+                assert commDict["nonblocking"] == False
+            else:
+                assert commDict["nonblocking"] == True
 
     gateFile = Path(workflow.getGatesFile())
     assert gateFile.is_file()
@@ -77,5 +81,8 @@ def test_ZMQGateCommunicator():
             assert commDict["protocolSettings"]["addr"] == "machine1"
             assert commDict["protocolSettings"]["port"] == 50000
             assert commDict["protocolSettings"]["bindingside"] == ZMQBindingSide.ZMQ_BIND_SENDER.name
-
+            if commDict["name"] == "senderSide":
+                assert commDict["nonblocking"] == False
+            else:
+                assert commDict["nonblocking"] == True
     launcher.removeFiles()


### PR DESCRIPTION
Add the ability for ZMQ communicators to be non blocking. If no message has been received, the get function will return an EMPTY flag.